### PR TITLE
Order packages alphabetically

### DIFF
--- a/SDSetupBackend/Controllers/v1.cs
+++ b/SDSetupBackend/Controllers/v1.cs
@@ -86,7 +86,7 @@ namespace SDSetupBackend.Controllers {
                     DeletingFileStream stream = (DeletingFileStream) ZipFromFilestreams(files.ToArray(), uuid);
 
                     Program.generatedZips[uuid] = stream;
-                    stream.Timeout(30000);
+                    stream.Timeout(180000);
 
                     Program.uuidLocks.Remove(uuid);
                     return new ObjectResult("READY");

--- a/SDSetupBackend/Program.cs
+++ b/SDSetupBackend/Program.cs
@@ -128,7 +128,7 @@ namespace SDSetupBackend {
                 foreach (string n in Directory.EnumerateDirectories(_Files)) {
                     string k = n.Split(Path.DirectorySeparatorChar).Last();
                     Manifest m = JsonConvert.DeserializeObject<Manifest>(File.ReadAllText((_Files + "/" + k + "/manifest6.json").AsPath()));
-                    foreach (string c in Directory.EnumerateDirectories((_Files + "/" + k).AsPath())) {
+                    foreach (string c in Directory.EnumerateDirectories((_Files + "/" + k).AsPath()).OrderBy(filename => filename)) {
                         string f = c.Split(Path.DirectorySeparatorChar).Last();
                         Package p = JsonConvert.DeserializeObject<Package>(File.ReadAllText((_Files + "/" + k + "/" + f + "/info.json").AsPath()));
                         m.Platforms[p.Platform].PackageSections[p.Section].Categories[p.Category].Subcategories[p.Subcategory].Packages[p.ID] = p;

--- a/SDSetupBlazor/Pages/Consoles.cshtml
+++ b/SDSetupBlazor/Pages/Consoles.cshtml
@@ -249,7 +249,7 @@
 
 
 			HttpClient client = new HttpClient();
-			client.Timeout = TimeSpan.FromSeconds(120);
+			client.Timeout = TimeSpan.FromSeconds(200);
 			HttpResponseMessage resp;
 			try {
 				HttpRequestMessage message = new HttpRequestMessage {


### PR DESCRIPTION
This PR adds an OrderBy so that packages are listed alphabetically in the manifest returned to the client.

Without this the sort order in undefined, as returned by the filesystem. (It appears to be by folder modification date currently...)